### PR TITLE
Verify confidence calculation and threshold

### DIFF
--- a/Bot-Trading_Swing (1).py
+++ b/Bot-Trading_Swing (1).py
@@ -14172,6 +14172,11 @@ class TransferLearningManager:
         logging.info(f"[Master Agent Coordinator] Starting coordinate_decision for {symbol}")
         
         try:
+            # Check if market_data is empty or insufficient
+            if market_data is None or (hasattr(market_data, 'empty') and market_data.empty) or len(market_data) < 10:
+                logging.warning(f"[Master Agent Coordinator] Insufficient data for {symbol}: {len(market_data) if market_data is not None else 0} rows")
+                return "HOLD", 0.25  # Lower confidence for insufficient data
+            
             # Decompose task
             subtasks = self.decompose_task(task_type, market_data)
             print(f" [Master Agent Coordinator] Decomposed tasks: {list(subtasks.keys())}")


### PR DESCRIPTION
Add early data sufficiency check to Master Agent and Transfer Learning Manager.

This ensures a "HOLD" decision with low confidence (0.25) is returned immediately when market data is insufficient, preventing further processing with unreliable data and clarifying the decision logic in such scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-640c0b3b-fe58-4638-861c-bb016020e6dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-640c0b3b-fe58-4638-861c-bb016020e6dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

