### PR TITLE
Fix bot trading script syntax error

### DIFF
--- a/Bot-Trading_Swing (1).py
+++ b/Bot-Trading_Swing (1).py
@@ -20370,9 +20370,9 @@ class EnhancedTradingBot:
             # Calculate final risk with Master Agent multiplier
             adjusted_risk = base_risk * allocation_multiplier * confidence_multiplier * llm_multiplier * master_agent_risk_multiplier * volatility_adjustment
 
-        # Production optimized risk limits - increased for better opportunities
-        max_safe_risk = base_risk * 1.5  # Increased from 1.2x
-        min_safe_risk = base_risk * 0.2  # Reduced from 0.3x
+            # Production optimized risk limits - increased for better opportunities
+            max_safe_risk = base_risk * 1.5  # Increased from 1.2x
+            min_safe_risk = base_risk * 0.2  # Reduced from 0.3x
             
             final_risk = min(max(adjusted_risk, min_safe_risk), max_safe_risk)
 


### PR DESCRIPTION
Indent `max_safe_risk` and `min_safe_risk` assignments to resolve a `SyntaxError` by correctly placing them within the `try` block.

---
<a href="https://cursor.com/background-agent?bcId=bc-e00f40bc-7fb5-4ea8-9a86-c7c11ad49fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e00f40bc-7fb5-4ea8-9a86-c7c11ad49fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

