### PR TITLE
Fix invalid decimal literal in bot trading script

### DIFF
--- a/Bot-Trading_Swing (1).py
+++ b/Bot-Trading_Swing (1).py
@@ -2965,7 +2965,7 @@ def _attempt_data_recovery_with_retry(symbol: str, timeframe: str, stale_minutes
         
     except Exception as e:
         logging.error(f"[Data Recovery] Recovery system error for {symbol} {timeframe}: {e}")
-        return False {timeframe} (stale {stale_minutes:.0f} minutes)")
+        return False
 
         # Use retry mechanism for data recovery
         recovery_client = DataRecoveryClient(use_async=False)


### PR DESCRIPTION
Fix `SyntaxError: invalid decimal literal` by correcting a malformed return statement in an exception handler.

The original line `return False {timeframe} (stale {stale_minutes:.0f} minutes)")` was syntactically incorrect, causing a `SyntaxError`. It was intended to simply return `False` when an exception occurred in the `_attempt_data_recovery_with_retry` function. The fix ensures the function correctly returns `False` on failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-e387c388-f82d-4eaf-96da-ce35db6707d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e387c388-f82d-4eaf-96da-ce35db6707d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

